### PR TITLE
Better error messages

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    exe.addOptions("options", options);
+    exe.root_module.addOptions("options", options);
     exe.linkLibC();
     b.installArtifact(exe);
 
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    unit_tests.addOptions("options", options);
+    unit_tests.root_module.addOptions("options", options);
     unit_tests.linkLibC();
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");

--- a/fixtures/malformed.zon
+++ b/fixtures/malformed.zon
@@ -11,11 +11,9 @@
             .url = "https://github.com/ziglibs/diffz/archive/90353d401c59e2ca5ed0abe5444c29ad3d7489aa.tar.gz",
             .hash = "122089a8247a693cad53beb161bde6c30f71376cd4298798d45b32740c3581405864",
         },
-        .binned_allocator = .{
+        binned_allocator = .{
             .url = "https://gist.github.com/antlilja/8372900fcc09e38d7b0b6bbaddad3904/archive/6c3321e0969ff2463f8335da5601986cf2108690.tar.gz",
             .hash = "1220363c7e27b2d3f39de6ff6e90f9537a0634199860fea237a55ddb1e1717f5d6a5",
         },
     },
-
-    .paths = .{},
 }

--- a/fixtures/missing-field.zon
+++ b/fixtures/missing-field.zon
@@ -13,9 +13,6 @@
         },
         .binned_allocator = .{
             .url = "https://gist.github.com/antlilja/8372900fcc09e38d7b0b6bbaddad3904/archive/6c3321e0969ff2463f8335da5601986cf2108690.tar.gz",
-            .hash = "1220363c7e27b2d3f39de6ff6e90f9537a0634199860fea237a55ddb1e1717f5d6a5",
         },
     },
-
-    .paths = .{},
 }

--- a/fixtures/with-path.zon
+++ b/fixtures/with-path.zon
@@ -12,10 +12,7 @@
             .hash = "122089a8247a693cad53beb161bde6c30f71376cd4298798d45b32740c3581405864",
         },
         .binned_allocator = .{
-            .url = "https://gist.github.com/antlilja/8372900fcc09e38d7b0b6bbaddad3904/archive/6c3321e0969ff2463f8335da5601986cf2108690.tar.gz",
-            .hash = "1220363c7e27b2d3f39de6ff6e90f9537a0634199860fea237a55ddb1e1717f5d6a5",
+            .path = "libs/zip",
         },
     },
-
-    .paths = .{},
 }

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690933134,
-        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691654369,
-        "narHash": "sha256-gSILTEx1jRaJjwZxRlnu3ZwMn1FVNk80qlwiCX8kmpo=",
+        "lastModified": 1700390070,
+        "narHash": "sha256-de9KYi8rSJpqvBfNwscWdalIJXPo8NjdIZcEJum1mH0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e",
+        "rev": "e4ad989506ec7d71f7302cc3067abd82730a4beb",
         "type": "github"
       },
       "original": {

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,13 +4,14 @@ const fs = std.fs;
 const heap = std.heap;
 const io = std.io;
 const process = std.process;
+const builtin = @import("builtin");
 
 const Dependency = @import("Dependency.zig");
 const fetch = @import("fetch.zig").fetch;
 const parse = @import("parse.zig").parse;
 const write = @import("codegen.zig").write;
 
-pub fn main() !void {
+pub fn run() !void {
     var args = process.args();
     _ = args.skip();
     const dir = fs.cwd();
@@ -35,6 +36,14 @@ pub fn main() !void {
     var out = io.bufferedWriter(io.getStdOut().writer());
     try write(alloc, out.writer(), deps);
     try out.flush();
+}
+
+pub fn main() !void {
+    if (builtin.mode == .Debug) {
+        try run();
+    } else {
+        run() catch std.os.exit(1);
+    }
 }
 
 comptime {

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -39,7 +39,8 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
             var has_url = false;
             var has_hash = false;
 
-            const dep_init = ast.fullStructInit(&buf, dep_idx) orelse {
+            var buf2: [2]Index = undefined;
+            const dep_init = ast.fullStructInit(&buf2, dep_idx) orelse {
                 return error.parseError;
             };
 

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -38,6 +38,7 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
             var hash: []const u8 = undefined;
             var has_url = false;
             var has_hash = false;
+            var has_path = false;
 
             var buf2: [2]Index = undefined;
             const dep_init = ast.fullStructInit(&buf2, dep_idx) orelse {
@@ -53,12 +54,14 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
                 } else if (mem.eql(u8, name, "hash")) {
                     hash = try parseString(alloc, ast, dep_field_idx);
                     has_hash = true;
+                } else if (mem.eql(u8, name, "path")) {
+                    has_path = true;
                 }
             }
 
             if (has_url and has_hash) {
                 _ = try deps.getOrPutValue(hash, dep);
-            } else {
+            } else if (!has_path) {
                 return error.parseError;
             }
         }


### PR DESCRIPTION
Adds error messages for all errors in `parse.zig` and changes the main function so it no longer prints a useless trace when compiled in release mode. This way the user gets an error that actually points towards the problem and is not presented with garbage output.

I added more files to the fixtures folder, but I did not add any tests for them because the error message is what matters, and I don't know if we can capture and test what error got printed.

This depends on #8 because it has an error message for missing url/hash or path in dependency.