### PR TITLE
Parse: create a different buffer for each struct init

### DIFF
--- a/src/parse.zig
+++ b/src/parse.zig
@@ -15,8 +15,8 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
 
     const ast = try Ast.parse(alloc, content, .zon);
 
-    var buf: [2]Index = undefined;
-    const root_init = ast.fullStructInit(&buf, ast.nodes.items(.data)[0].lhs) orelse {
+    var root_buf: [2]Index = undefined;
+    const root_init = ast.fullStructInit(&root_buf, ast.nodes.items(.data)[0].lhs) orelse {
         return error.ParseError;
     };
 
@@ -25,7 +25,8 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
             continue;
         }
 
-        const deps_init = ast.fullStructInit(&buf, field_idx) orelse {
+        var deps_buf: [2]Index = undefined;
+        const deps_init = ast.fullStructInit(&deps_buf, field_idx) orelse {
             return error.ParseError;
         };
 
@@ -39,7 +40,8 @@ pub fn parse(alloc: Allocator, deps: *StringHashMap(Dependency), file: File) !vo
             var has_url = false;
             var has_hash = false;
 
-            const dep_init = ast.fullStructInit(&buf, dep_idx) orelse {
+            var dep_buf: [2]Index = undefined;
+            const dep_init = ast.fullStructInit(&dep_buf, dep_idx) orelse {
                 return error.parseError;
             };
 


### PR DESCRIPTION
The issue seems to present itself only when `build.zig.zon` has exactly two dependencies. I noticed that the indexes inside `deps_init.ast.fields` changed just after the call to `const dep_init = ast.fullStructInit(&buf, dep_idx)`. The only side effect of that call is `buf`. This is because the value of `*.ast.fields` is just a pointer to the provided buffer so it cannot be reused if the parent ast still needs to be used (for the parent for-loop in this case).

Without this fix:
```
/home/user/repos/zon2nix/src/parse.zig:43:17: 0x24c663 in parse (zon2nix)
                return error.parseError;
                ^
/home/user/repos/zon2nix/src/main.zig:32:5: 0x25154b in main (zon2nix)
    try parse(alloc, &deps, file);
    ^
```