### PR TITLE
Support Git tags

### DIFF
--- a/src/fetch.zig
+++ b/src/fetch.zig
@@ -41,7 +41,11 @@ pub fn fetch(alloc: Allocator, deps: *StringHashMap(Dependency)) !void {
             const ref = ref: {
                 const base = base: {
                     if (dep.rev) |rev| {
-                        break :base try fmt.allocPrint(alloc, "git+{s}?rev={s}", .{ dep.url, rev });
+                        if (rev.len == 40)
+                            // TODO: Differentiate between 40-character tags and commit hashes
+                            break :base try fmt.allocPrint(alloc, "git+{s}?rev={s}", .{ dep.url, rev })
+                        else
+                            break :base try fmt.allocPrint(alloc, "git+{s}?ref=refs/tags/{s}", .{ dep.url, rev });
                     } else {
                         break :base try fmt.allocPrint(alloc, "tarball+{s}", .{dep.url});
                     }


### PR DESCRIPTION
One of the dependencies in
[raylib](https://github.com/raysan5/raylib/blob/master/build.zig.zon) has git rev 3.1.50, causing Nix to complain it is not a valid sha1 hash. I added a naive check that checks if the rev is exactly 40 characters. The only time I see this becoming an issue is if a tag's length is exactly 40 characters, but that happening in the wild is very unlikely.