### PR TITLE
Update to Zig 0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.16.0-dev.2471+e9eadee00
+          version: 0.16.0
 
       - uses: DeterminateSystems/nix-installer-action@main
 
@@ -31,14 +31,14 @@ jobs:
       - name: Run executable on zls
         run: |
           git clone https://github.com/zigtools/zls
-          nix run .#overlay_0_16 -- zls
-          nix run . -- zls
+          nix run .# -- zls
+          nix run .# -- zls
 
       - name: Run integration tests for issue 60
         run: |
           nix --version
-          nix run .#overlay_0_16_debug -- fixtures/integrationtest/issue60-1-build.zig.zon
-          nix run .#overlay_0_16_debug -- fixtures/integrationtest/issue60-2-build.zig.zon
+          nix run .# -- fixtures/integrationtest/issue60-1-build.zig.zon
+          nix run .# -- fixtures/integrationtest/issue60-2-build.zig.zon
 
   format:
     name: format
@@ -50,7 +50,7 @@ jobs:
       - name: Set up zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.16.0-dev.2471+e9eadee00
+          version: 0.16.0
 
       - name: Check formatting
         run: zig fmt --check .

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ To use the generated file, add this to your Nix expression:
 
 ```nix
 postPatch = ''
-  ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
+  # For Zig version < 0.16.0, uncomment the following line
+  # ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
+  # For Zig version >= 0.16.0
+  ln -s ${pkgs.callPackage ./nix/deps.nix { }} zig-pkg
 '';
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -36,31 +20,13 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742288794,
-        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -73,45 +39,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "zig-overlay": "zig-overlay"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "zig-overlay": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770165742,
-        "narHash": "sha256-q7nu9F2ZtmIU9BMarY8BLIEfiwPwrjXGXLvOdFSvQP4=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "364ec9318bc70fc1ec084cb41e80e90d6770dd2b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -34,40 +34,18 @@
         let
           inherit (pkgs)
             callPackage
-            zigpkgs
             zig_0_13
             zig_0_14
+            zig_0_15
+            zig_0_16
             ;
-          zig_0_16 = zigpkgs.master-2026-02-03;
-          zig_0_16_for_overlay = zig_0_16.overrideAttrs (
-            f: p: {
-                passthru.hook = callPackage "${inputs.nixpkgs}/pkgs/development/compilers/zig/hook.nix" {
-                  zig = pkgs.lib.recursiveUpdate f.finalPackage {
-                    # Aparantly, `platforms` and `maintainers` are missing from the nightly. We use the ones
-                    # from 0.14, assuming that the values are the same.
-                    meta = { inherit (zig_0_14.meta) platforms maintainers; };
-                  };
-                };
-              }
-          );
         in
         {
           packages = {
-            default = callPackage ./nix/package.nix {
-              zig = zigpkgs.master.overrideAttrs (
-                f: p: {
-                  inherit (zig_0_14) meta;
-
-                  passthru.hook = callPackage "${inputs.nixpkgs}/pkgs/development/compilers/zig/hook.nix" {
-                    zig = f.finalPackage;
-                  };
-                }
-              );
-            };
-            default_0_14 = callPackage ./nix/package.nix { zig = zig_0_14; };
+            default = callPackage ./nix/package.nix { zig = zig_0_16; };
             default_0_13 = callPackage ./nix/package.nix { zig = zig_0_13; };
-            overlay_0_16 = callPackage ./nix/package.nix { zig = zig_0_16_for_overlay; };
-            overlay_0_16_debug = callPackage ./nix/package.nix { zig = zig_0_16_for_overlay; debug = true; };
+            default_0_14 = callPackage ./nix/package.nix { zig = zig_0_14; };
+            default_0_15 = callPackage ./nix/package.nix { zig = zig_0_15; };
           };
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,6 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    zig-overlay = {
-      url = "github:mitchellh/zig-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -52,14 +52,6 @@
           );
         in
         {
-          _module.args.pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [
-              inputs.zig-overlay.overlays.default
-            ];
-            config = { };
-          };
-
           packages = {
             default = callPackage ./nix/package.nix {
               zig = zigpkgs.master.overrideAttrs (

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   src = ../.;
 
   nativeBuildInputs = [
-    zig.hook
+    zig
   ];
 
   zigBuildFlags = [


### PR DESCRIPTION
This PR updates to Zig 0.16. We can take the stock version from nixpkgs, which makes considerable complexity in flake.nix obsolete. I've removed this.

By the way: the latest tagged version is 0.1.2 back from 2023-09-04. A lot has happened since then. I think this project needs a new tag: 0.2.0.