### PR TITLE
Read from stdin when it makes sense

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -36,8 +36,11 @@ pub fn main(init: std.process.Init) !void {
             (try dir.openDir(io, path, .{})).openFile(io, "build.zig.zon", .{})
         else
             dir.openFile(io, path, .{})
+    else if (try std.Io.File.stdin().isTty(io))
+        dir.openFile(io, "build.zig.zon", .{})
     else
-        dir.openFile(io, "build.zig.zon", .{});
+        std.Io.File.stdin();
+
     defer file.close(io);
 
     const gpa, const is_debug = gpa: {


### PR DESCRIPTION
It makes sense to read from stdin when no paths have been passed via cli args and also when stdin is not a tty. This ignore `</dev/null` because I don't think that its very likely to ever occur.